### PR TITLE
Added a set of utilities for automatic grading, and updated documentatio...

### DIFF
--- a/handin-server/grading-utils.rkt
+++ b/handin-server/grading-utils.rkt
@@ -1,0 +1,204 @@
+#lang racket
+
+(require racket/date)
+(require handin-server/checker)
+(require handin-server/private/config)
+(require web-server/private/timer)
+(require (only-in handin-server/utils get-assignment-name))
+
+(provide check-deadline
+         check-max-submissions 
+         
+         update-submission-timestamp!
+         get-submission-timestamp         
+         
+         set-test-max-score!
+         score-add-penalty!
+         
+         add-report-line!         
+         with-output-to-report         
+         add-score-to-report!
+         write-report
+         
+         @test
+         @test/exn)
+
+(define student-score (make-thread-cell #f))
+(define test-max-score (make-thread-cell #f))
+(define submission-timestamp (make-thread-cell #f))
+
+;; set-test-max-score!: positive int -> void
+(define (set-test-max-score! max-score)
+  (let ([cur-student-score (thread-cell-ref student-score)]
+        [cur-test-max-score (thread-cell-ref test-max-score)])
+    (if cur-student-score
+        (set-box! cur-student-score max-score)
+        (thread-cell-set! student-score (box max-score)))
+    (if cur-test-max-score
+        (set-box! cur-test-max-score max-score)
+        (thread-cell-set! test-max-score (box max-score)))))
+
+(define (update-submission-timestamp!)
+  (let ([cur-submission-timestamp (thread-cell-ref submission-timestamp)])
+    (define ts (begin (date-display-format 'iso-8601)
+                      (date->string (current-date) #t)))
+    (if cur-submission-timestamp
+        (set-box! cur-submission-timestamp ts)
+        (thread-cell-set! submission-timestamp (box ts)))))
+
+;; penalty must be a positive number
+(define (score-add-penalty! penalty)
+  (let ([cur-student-score (thread-cell-ref student-score)])
+    (if cur-student-score
+        (set-box! cur-student-score (max 0 (- (get-student-score) penalty)))
+        (error "student-score should be initialized already"))))
+
+(define (get-student-score) (unbox (thread-cell-ref student-score)))
+
+(define (get-test-max-score) (unbox (thread-cell-ref test-max-score)))
+
+(define (get-submission-timestamp)
+  (let ([cur-submission-timestamp (thread-cell-ref submission-timestamp)])
+    (if cur-submission-timestamp
+        (unbox cur-submission-timestamp)
+        #f)))  
+
+(define (add-score-to-report!)
+  (add-report-line! (format "Final Score: ~a out of ~a"
+                            (get-student-score)
+                            (get-test-max-score))))
+
+(define report-lines (make-thread-cell #f))
+
+(define (add-report-line! line)
+  (let ([new (list line)]
+        [cur (thread-cell-ref report-lines)])
+    (if cur
+        (set-box! cur (append (unbox cur) new))
+        (thread-cell-set! report-lines (box new)))))
+
+(define (get-report-delay-in-minutes) 
+  (with-handlers ([exn? (thunk* 0)])
+    (get-conf 'report-delay-in-minutes)))
+
+(define-syntax (write-report stx)
+  (define (id s) (datum->syntax stx s stx))
+  (syntax-case stx ()
+    [(write-report)
+     (with-syntax ([users (id 'users)])
+       #'(begin
+           (define dir (build-path (current-directory) 'up))
+           (define ts (get-submission-timestamp))
+           (define (report->string users)
+             (with-output-to-string
+              (lambda ()
+                (for-each (lambda (str) (printf "~a\n" str))
+                          (cond [(thread-cell-ref report-lines) => unbox]
+                                [else '()])))))  
+           (define report-string (report->string users))
+           (define report-delay (get-report-delay-in-minutes))
+           (start-timer (* 60 report-delay)
+                        (thunk
+                         (with-output-to-file
+                             (build-path dir 
+                                         (format "~a-report-~a.txt"
+                                                 (string-join users "+")                                        
+                                                 ts))
+                           #:exists 'replace
+                           (thunk (display report-string)))))
+           (message (string-append "Your submission has been accepted."
+                                   (format " A report with timestamp ~a will be available after ~a minutes"
+                                           ts
+                                           report-delay))
+                    '(ok))))]))
+
+(define (get-deadline-seconds dir-name)
+  (match (assoc dir-name (get-conf 'deadline))
+    [(list _ (list year month day hours minutes seconds) max-late-days)
+     (values (find-seconds seconds minutes hours day month year)
+             (find-seconds seconds minutes hours (+ day max-late-days) month year))]
+    [else #f]))
+
+
+(define (check-deadline)
+  (define dir-name (get-assignment-name))
+  (set-run-status "Checking submission against deadline")  
+  (define-values (deadline deadline+late-days) (get-deadline-seconds dir-name))
+  (define now (current-seconds))
+  (when (and deadline (> now deadline))
+    (cond
+      [(> now deadline+late-days) (error "Your submission is rejected because it is past the deadline + extra days")]
+      [else (message "Your submission is accepted but it is late, you will get a discount in your grade" '(ok))])))
+
+(define (success-dir n) (format "SUCCESS-~a" n))
+(define SUCCESS-RE (regexp (format "^~a$" (success-dir "[0-9]+"))))
+
+(define (successful-submissions)
+  ;; Find the number of SUCCESS-? dirs in the user directory
+  (let ([dirlist (map path->string (directory-list ".."))])      
+    (length (filter (lambda (d)
+                      (and (directory-exists? (string->path (format "../~a" d)))
+                           (regexp-match SUCCESS-RE d)))
+                    dirlist))))
+
+(define (check-max-submissions)
+  (define dir-name (get-assignment-name))
+  (set-run-status "Checking against maximum number of submissions")
+  (let ([max-submissions-conf (assoc dir-name (get-conf 'max-submissions))])      
+    ;; setting max-submissions <= 0 means unlimited submissions
+    (when max-submissions-conf
+      (let ([max-submissions (second max-submissions-conf)]
+            [used-submissions (successful-submissions)])
+        (when (> max-submissions 0)
+          (if (>= used-submissions max-submissions)
+              (error (format "You already used your ~a submissions" max-submissions))
+              (case (message (string-append "Are you sure you want to proceed? "
+                                            (format "If this submission is successful you will have ~a out of ~a"
+                                                    (- max-submissions used-submissions 1)
+                                                    max-submissions)
+                                            "submissions left.")
+                             '(yes-no))
+                ((no) (error "Submission aborted by user")))))))))
+
+(define-syntax with-output-to-report
+  (syntax-rules ()
+    [(_ expr ...)     
+     (let ([output-port (open-output-string)])
+       (parameterize ([current-output-port output-port])
+         (call-with-values
+          (λ () expr ...)
+          (λ args
+            (close-output-port output-port)
+            (add-report-line! (get-output-string output-port))
+            (apply values args)))))]))
+
+(define-syntax @test
+  (syntax-rules ()
+    [(_ test-desc error-desc expr result penalty)
+     (@test test-desc error-desc expr result equal? penalty)]
+    
+    [(_ test-desc error-desc expr result equal? penalty)
+     (with-handlers
+         ([exn? (λ (exn) 
+                  (with-output-to-report
+                   (displayln (exn-message exn))
+                   (score-add-penalty! penalty)
+                   (newline)
+                   (displayln (format "Penalty: ~a" penalty))))])
+       (with-output-to-report
+        (display (format "Test: ~a" test-desc)))
+       (!test expr result equal?))]))
+
+(define-syntax @test/exn
+  (syntax-rules ()
+    [(_ test-desc expr penalty)
+     (with-handlers
+         ([exn? (λ (exn) 
+                  (with-output-to-report
+                   (display (exn-message exn))
+                   (score-add-penalty! penalty)
+                   (display (format "Penalty: ~a" penalty))))])
+       (with-output-to-report
+        (display (format "Test: ~a" test-desc)))
+       (!test/exn expr))]))
+

--- a/handin-server/scribblings/grading-utils.scrbl
+++ b/handin-server/scribblings/grading-utils.scrbl
@@ -1,0 +1,232 @@
+#lang scribble/doc
+@(require "common.rkt")
+
+@title[#:tag "grading-utils"]{Grading Utilities}
+
+@defmodule[handin-server/grading-utils]
+
+This module provides utilities that can serve as the basis for an automated
+grading system. In particular, it provides:
+
+@itemlist[
+
+@item{A mechanism to establish deadlines with or without allowing late
+submissions. The idea is to avoid having someone stop the server at midnight in
+order to stop accepting submissions.}
+
+@item{A mechanism to establish a maximum number of submissions. The idea is
+that students can get limited feedback before doing the definitive submission.}
+
+@item{A mechanism to keep track of the user's score, and where failed tests add
+a penalty to that score.}
+
+@item{A mechanism to create a report (a text file) of the evaluation of the submission,
+instead of reporting errors immediately when they are found. Moreover, it is
+possible to delay the publication of this report, in order to avoid potential
+abuses from the students.}
+
+]
+
+The following example illustrates a checker module using this infrastructure:
+
+@racketblock[
+
+(module checker handin-server/checker 
+  
+  (require handin-server/grading-utils)
+
+  (code:comment "Checks that submission is on time and that the user has submissions left")
+  (pre:
+   (check-deadline)
+   (check-max-submissions))
+  
+  (code:comment "Ends the report by adding the score and writes it in the user directory")
+  (code:comment "This way, students can see their reports from the web interface.")
+  (post:
+   (add-score-to-report!)
+   (write-report))
+  
+  (check:   
+   (code:comment "Get timestamp of the submission and add it to header and report")
+   (update-submission-timestamp!)
+   (add-header-line! (get-submission-timestamp))
+   (add-report-line! (get-submission-timestamp))
+   
+   (code:comment "Acceptance tests: reject the submission if any of these tests fail")
+   (!test (foo 1) 3)
+   (code:comment "...")
+   
+   (code:comment "Grading")
+   
+   (code:comment "Initialize max score")
+   (set-test-max-score! 100)
+   
+   (code:comment "Failure discounts 25 points")
+   (@test "Sample case 1"
+          "Error using even? predicate"
+          (bar '(1 2 3 4) even?)
+          '((2 4)(1 3))
+          25)
+   ))
+]
+
+@defproc[(check-deadline) void]{
+
+  Checks if the current submission is within the deadline specified for the
+  corresponding assignment. If the submission is past this deadline, a submit
+  error is thrown. If no deadline is specified the check is trivially
+  passed. This function is intended to be used in the pre-checker stage.
+
+Deadlines are configured in the @filepath{config.rktd} file (see
+  @secref{server-setup}), in a per-assignment basis, through the
+  @indexed-racket{deadline} key. This is an optional keyword that holds an
+  association list where each sublist has three elements:
+
+@itemlist[
+
+@item{the assignment name, which must coincide with the name used in the
+@racket{active-dir} key}
+
+@item{the deadline date, specified as a list @racket{(year month day hour minutes seconds)}}
+
+@item{a non-negative integer indicating the amount of days allowed for late
+submissions. If this value is @code{0} then the deadline is strict. Late
+submissions are marked as such in the report and in the textual version of the
+submission (if created).}
+
+]
+
+ Consider an example configuration:
+
+@verbatim[#:indent 2]{ @;
+(deadline (("Assignment 1" (2014 3 11 23 59 59) 3)))
+}
+
+}
+
+@defproc[(check-max-submissions) void]{
+
+If the assignment has a limited number of submissions, it checks whether the
+user has already used up all of them. If the user has no submissions left, the
+current one is rejected. This check is intended for use in the pre-checker stage.
+
+By default users have an unlimited number of submissions. Restrictions on the
+number of submissions must be defined in the @filepath{config.rktd} file,
+through the optional @racket[max-submissions] key. This key must hold an
+association where each sublist has two elements: the assignment name, and a
+non-negative integer specifying the allowed submissions. For example:
+
+@verbatim[#:indent 2]{@;
+(max-submissions (("Assignment 1 5)))
+}
+
+@racket[check-max-submissions] only counts the number of existing successful
+submissions, more specifically, it counts the number of @racket{"SUCCESS-n"}
+directories specific to each user. Therefore, submissions that rejected by the
+pre-checker or checker do not count against the submission limit.
+
+}
+
+@defproc[(update-submission-timestamp!) void]{@;
+
+Sets the current timestamp as a thread-local value that can be later retrieved
+using @racket[get-submission-timestamp]. This value can be then used to
+identify submissions and related files, like reports or grading files. The
+rationale is that we cannot use the @racket{"SUCCESS-n"} names because they
+will change after new submissions.
+
+}
+
+@defproc[(get-submission-timestamp) string?]{@;
+
+ Returns an string representing the latest timestamp value stored using
+@racket[update-submission-timestamp!].
+
+}
+
+@defproc[(set-test-max-score! [max-score positive?]) void]{ @;
+
+Sets @racket[max-score] as the maximum score possible for this submission, and
+initializes the student's score to this value. Penalties are only applied to
+the student's score, while the maximum score is available for reference only.
+
+}
+
+@defproc[(score-add-penalty! [penalty (or/c zero? positive?)]) void]{ @;
+
+Discounts @racket[penalty] points from the student's score.
+
+}
+
+@defproc[(add-report-line! [line string?]) void]{ @;
+
+Like @racket[add-header-line!], but it writes to the report instead of the
+textual version of the submission.
+
+}
+
+@defform[(with-output-to-report expr ...)]{ @;
+
+Evaluates @racket[expr ...] and redirects output to the report bound to this
+submission. Similar to @racket[with-output-to-string] or
+@racket[with-output-to-file].
+
+}
+
+@defproc[(add-score-to-report!) void]{ @;
+
+An utility function, defined as:
+
+@racketblock[
+(define (add-score-to-report!)
+  (add-report-line! (format "Final Score: ~a out of ~a"
+                            (get-student-score)
+                            (get-test-max-score))))
+]
+}
+
+@defform[(write-report)]{ @;
+
+Writes the report bound to the current submission into the root of the user
+folder of the corresponding assignment (for example @filepath{Assignment
+1/tester}). By default, the report is written immediately to this folder. It is
+possible to configure the delay in the @filepath{config.rktd} file, using the
+@racket[report-delay-in-minutes] key. The value of this key must be a
+non-negative number, for example:
+
+@verbatim[#:indent 2]{ @;
+(report-delay-in-minutes 5)
+}
+
+Internally, the macro calls the @racket[start-timer] procedure in the following
+way:
+
+@racketblock[
+(define-syntax (write-report stx)
+   ...
+   (define report-delay (get-report-delay-in-minutes))
+   (start-timer (* 60 report-delay) ...))
+]
+
+The default behavior is obtained because @racket[get-report-delay-in-minutes]
+returns @racket[0] if the key is not found in @filepath{config.rktd}.
+
+}
+
+@defform*[((\@test test-desc error-desc expr result penalty)
+           (\@test test-desc error-desc expr result equal? penalty))]{ @;
+
+Like @racket[!test], but is designed to work with a report and a user score. It
+evaluates @racket[(!test expr result)] or @racket[(!test expr result equal?)]
+and redirects the output to the report. If the test fails, the error message is
+written to the report and no exception is thrown, and the @racket[penalty] is
+added to the score of the user.
+
+}
+
+@defform[(\@test/exn expr penalty)]{ @;
+
+Like @racket[!test/exn] but the output is redirected to the report. In case of
+error, the message is written to the report instead of raising an exception.
+
+}

--- a/handin-server/scribblings/handin-server.scrbl
+++ b/handin-server/scribblings/handin-server.scrbl
@@ -20,5 +20,6 @@
 @include-section["server-setup.scrbl"]
 @include-section["checker-utils.scrbl"]
 @include-section["other-utils.scrbl"]
+@include-section["grading-utils.scrbl"]
 
 @index-section[]

--- a/handin-server/scribblings/server-setup.scrbl
+++ b/handin-server/scribblings/server-setup.scrbl
@@ -212,6 +212,21 @@ This directory contains the following files and sub-directories:
              (map (lambda (key+val)
                     (apply format "~a: ~s" key+val))
                   alist))))]}}]
+  
+
+  The @secref{grading-utils} uses the following keys:
+  
+  @itemlist[
+
+     @item{@indexed-racket[deadline]: sets a per-assignment deadline for submissions,
+     while optionally allowing a number of days for late submissions.}
+
+     @item{@indexed-racket[max-submissions] sets a per-assignment limit to the
+     quantity of submissions that users can send.}
+  
+     @item{@indexed-racket[report-delay-in-minutes]: specifies the delay after
+     which the report of the submission is written to the user folder of the
+     corresponding assignment.}]
 
   In addition, you can add your own keys --- see @racket[get-conf] for
   details.

--- a/handin-server/utils.rkt
+++ b/handin-server/utils.rkt
@@ -2,7 +2,7 @@
 
 (require racket/class racket/gui/base racket/pretty
          (prefix-in pc: mzlib/pconvert)
-         (only-in "main.rkt" timeout-control)
+         (only-in "main.rkt" timeout-control get-user-assignment-directory get-assignment-name)
          "private/run-status.rkt"
          "private/config.rkt"
          "private/logger.rkt"
@@ -33,7 +33,10 @@
          user-construct
          test-history-enabled
 
-         timeout-control)
+         timeout-control
+         
+         get-user-assignment-directory
+         get-assignment-name)
 
 (define (unpack-submission str)
   (let* ([base (make-object editor-stream-in-bytes-base% str)]


### PR DESCRIPTION
Added a few utilities intended for automatic grading, namely:

- a mechanism to establish per-assignment deadlines and extra days for late submissions
- a mechanism to establish a per-assignment limited number of submissions
- a way to create a report as a text file, which is written into the user folder (so is visible from the web interface). The report by default is written immediately, but a delay can be configured.
- a way to set the score of a student, and macros to perform tests and add penalties if these tests fail
- a scribbling documenting these features

I've tried to integrate as smoothly as possible with the design of the handin-server, but for convenience when writing the report I defined two new parameters in main.rkt, namely:

- assignment-name: bound to the folder name of the assignment corresponding to the submission processed by the checker

- user-assignment-directory: bound to the root of the user folder corresponding to the current assignment (e.g. "Assignment 1/tester")

Finally, there is some layout changes in some files, which occurred after I used Command-I shortcut in DrRacket, so I /guess/ it should be fine...