### PR TITLE
Use `ssl-load-default-verify-sources!' in the client.

### DIFF
--- a/handin-client/client.rkt
+++ b/handin-client/client.rkt
@@ -35,6 +35,7 @@
   (define pem (in-this-collection "server-cert.pem"))
   (define ctx (ssl-make-client-context))
   (ssl-set-verify! ctx #t)
+  (ssl-load-default-verify-sources! ctx)
   (ssl-load-verify-root-certificates! ctx pem)
   (with-handlers
       ([exn:fail:network?


### PR DESCRIPTION
This is needed when we use a signed certificate.

At least it looks like this should work fine, I'll know more in a few days when my students use it for submission.
