### PR TITLE
Send language header

### DIFF
--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -708,15 +708,6 @@
 
 (define handin-icon (scale-by-half (in-this-collection "icon.png")))
 
-(define (editors->string editors)
-  (let* ([base (make-object editor-stream-out-bytes-base%)]
-         [stream (make-object editor-stream-out% base)])
-    (write-editor-version stream base)
-    (write-editor-global-header stream)
-    (for ([ed (in-list editors)]) (send ed write-to-file stream))
-    (write-editor-global-footer stream)
-    (send base get-bytes)))
-
 (define (string->editor! str defs)
   (let* ([base (make-object editor-stream-in-bytes-base% str)]
          [stream (make-object editor-stream-in% base)])
@@ -737,6 +728,15 @@
       (if updater?
         (dynamic-require `(lib "updater.rkt" ,this-collection-name) 'bg-update)
         void))
+
+    (define (editors->string editors)
+      (let* ([base (make-object editor-stream-out-bytes-base%)]
+             [stream (make-object editor-stream-out% base)])
+        (write-editor-version stream base)
+        (write-editor-global-header stream)
+        (for ([ed (in-list editors)]) (send ed write-to-file stream))
+        (write-editor-global-footer stream)
+        (send base get-bytes)))
 
     (define tool-button-label (bitmap-label-maker button-label/h handin-icon))
 

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -729,12 +729,12 @@
         (dynamic-require `(lib "updater.rkt" ,this-collection-name) 'bg-update)
         void))
 
-    (define (editors->string editors)
+    (define (editors->string definitions interactions)
       (let* ([base (make-object editor-stream-out-bytes-base%)]
              [stream (make-object editor-stream-out% base)])
         (write-editor-version stream base)
         (write-editor-global-header stream)
-        (for ([ed (in-list editors)]) (send ed write-to-file stream))
+        (for ([ed (in-list (list definitions interactions))]) (send ed write-to-file stream))
         (write-editor-global-footer stream)
         (send base get-bytes)))
 
@@ -793,8 +793,8 @@
                [callback
                 (lambda (button)
                   (let ([content (editors->string
-                                  (list (get-definitions-text)
-                                        (get-interactions-text)))])
+                                  (get-definitions-text)
+                                  (get-interactions-text))])
                     (new handin-frame%
                          [parent this]
                          [content content]


### PR DESCRIPTION
Fix racket/handin#17 by loading the language metadata from the DrRacket
configuration and prepending it to a clone of the definitions editor
before serializing this clone.

Warning: This hard-codes the module name to `'handin`, which doesn't
sound very good, but I'm not sure what's an obviously better option, since that's the filename on the server. Also, we can't always use the client module name, since the file on the client might not have been saved.