### PR TITLE
Share image teachpack between sandbox and checker.

### DIFF
--- a/handin-server/sandbox.rkt
+++ b/handin-server/sandbox.rkt
@@ -17,7 +17,10 @@
    `(,(car specs)
      ,@(cdr specs)
      lang/posn
-     ,@(if gui? '(mrlib/cache-image-snip) '()))))
+     ; for htdp/image
+     mrlib/cache-image-snip
+     ; for 2htdp/image
+     mrlib/image-core)))
 
 ;; local overrides
 (require racket/runtime-path)


### PR DESCRIPTION
The image type is generative, so we have to be careful not to get two
different image types inside and outside the sandbox.

This code probably tried to achieve that*, but failed for two reasons:
- gui? is false here, but that's irrelevant -- we better allow images
  even for headless servers. We could change through `(require
  racket/gui)` before `(require racket/sandbox)`, but that seems
  pointless. I'm not sure if this can be hidden by particular checkers.
- for 2htdp/image, we need to load a different implementation of image
  from htdp/image.

This suggests the docs for sandbox-namespace-specs should also be
updated.
- I'm guessing from docs of sandbox-namespace-specs, but they're
  hopelessly vague - see
  http://docs.racket-lang.org/reference/Sandboxed_Evaluation.html?q=sandbox-namespace-specs#%28def._%28%28lib._racket%2Fsandbox..rkt%29._sandbox-namespace-specs%29%29
