### PR TITLE
Send and retrieve language header

### DIFF
--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -729,15 +729,15 @@
         (dynamic-require `(lib "updater.rkt" ,this-collection-name) 'bg-update)
         void))
 
-    (define (get-lang-prefix modname)
-      (let* ([lang-settings (preferences:get (drracket:language-configuration:get-settings-preferences-symbol))]
+    (define (get-lang-prefix modname editor)
+      (let* ([lang-settings (send editor get-next-settings)]
              [lang (drracket:language-configuration:language-settings-language lang-settings)]
              [settings (drracket:language-configuration:language-settings-settings lang-settings)])
         (send lang get-metadata modname settings)))
 
     (define (with-fake-header editor)
       (let ([new-editor (send editor copy-self)]
-            [text (get-lang-prefix 'handin)])
+            [text (get-lang-prefix 'handin editor)])
         (when text
           (send new-editor set-position 0)
           (send new-editor insert-port (open-input-string text)))

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -730,9 +730,9 @@
         void))
 
     (define (get-lang-prefix modname)
-      (let* ([pref (preferences:get (drracket:language-configuration:get-settings-preferences-symbol))]
-             [lang (drracket:language-configuration:language-settings-language pref)]
-             [settings (drracket:language-configuration:language-settings-settings pref)])
+      (let* ([lang-settings (preferences:get (drracket:language-configuration:get-settings-preferences-symbol))]
+             [lang (drracket:language-configuration:language-settings-language lang-settings)]
+             [settings (drracket:language-configuration:language-settings-settings lang-settings)])
         (send lang get-metadata modname settings)))
 
     (define (with-fake-header editor)

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -708,15 +708,6 @@
 
 (define handin-icon (scale-by-half (in-this-collection "icon.png")))
 
-(define (editors->string editors)
-  (let* ([base (make-object editor-stream-out-bytes-base%)]
-         [stream (make-object editor-stream-out% base)])
-    (write-editor-version stream base)
-    (write-editor-global-header stream)
-    (for ([ed (in-list editors)]) (send ed write-to-file stream))
-    (write-editor-global-footer stream)
-    (send base get-bytes)))
-
 (define (string->editor! str defs)
   (let* ([base (make-object editor-stream-in-bytes-base% str)]
          [stream (make-object editor-stream-in% base)])
@@ -737,6 +728,15 @@
       (if updater?
         (dynamic-require `(lib "updater.rkt" ,this-collection-name) 'bg-update)
         void))
+
+    (define (editors->string editors)
+      (let* ([base (make-object editor-stream-out-bytes-base%)]
+             [stream (make-object editor-stream-out% base)])
+        (write-editor-version stream base)
+        (write-editor-global-header stream)
+        (for ([ed (in-list editors)]) (send ed write-to-file stream))
+        (write-editor-global-footer stream)
+        (send base get-bytes)))
 
     (define tool-button-label (bitmap-label-maker button-label/h handin-icon))
 

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -708,16 +708,6 @@
 
 (define handin-icon (scale-by-half (in-this-collection "icon.png")))
 
-(define (string->editor! str defs)
-  (let* ([base (make-object editor-stream-in-bytes-base% str)]
-         [stream (make-object editor-stream-in% base)])
-    (read-editor-version stream base #t)
-    (read-editor-global-header stream)
-    (send* defs (begin-edit-sequence #f)
-                (erase) (read-from-file stream)
-                (end-edit-sequence))
-    (read-editor-global-footer stream)))
-
 (define tool@
   (unit
     (import drracket:tool^)
@@ -752,6 +742,16 @@
         (for ([ed (in-list (list definitions-with-fake-header interactions))]) (send ed write-to-file stream))
         (write-editor-global-footer stream)
         (send base get-bytes)))
+
+    (define (string->editor! str defs)
+      (let* ([base (make-object editor-stream-in-bytes-base% str)]
+             [stream (make-object editor-stream-in% base)])
+        (read-editor-version stream base #t)
+        (read-editor-global-header stream)
+        (send* defs (begin-edit-sequence #f)
+          (erase) (read-from-file stream)
+          (end-edit-sequence))
+        (read-editor-global-footer stream)))
 
     (define tool-button-label (bitmap-label-maker button-label/h handin-icon))
 

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -729,12 +729,12 @@
         (dynamic-require `(lib "updater.rkt" ,this-collection-name) 'bg-update)
         void))
 
-    (define (editors->string editors)
+    (define (editors->string definitions interactions)
       (let* ([base (make-object editor-stream-out-bytes-base%)]
              [stream (make-object editor-stream-out% base)])
         (write-editor-version stream base)
         (write-editor-global-header stream)
-        (for ([ed (in-list editors)]) (send ed write-to-file stream))
+        (for ([ed (in-list (list definitions interactions))]) (send ed write-to-file stream))
         (write-editor-global-footer stream)
         (send base get-bytes)))
 
@@ -793,8 +793,8 @@
                [callback
                 (lambda (button)
                   (let ([content (editors->string
-                                  (list (get-definitions-text)
-                                        (get-interactions-text)))])
+                                  (get-definitions-text)
+                                  (get-interactions-text))])
                     (new handin-frame%
                          [parent this]
                          [content content]


### PR DESCRIPTION
Improved version of #22, fixing #17.
In comparison:
- this sends metadata for the current buffer, not for the last language preference set on any buffer. Thanks to @rfindler for confirming the fix on [racket-users](https://groups.google.com/d/msg/racket-users/-6u3ip3v9eU/U5-v5q4rAQAJ).
- this reloads the metadata on retrieve, reusing DrRacket logic.

Warning: I haven't stress-tested this yet.