### PR TITLE
Improve handin-server scalability under load.

### DIFF
--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -4,6 +4,7 @@
          racket/port
          openssl
          racket/file
+         racket/format
          "private/logger.rkt"
          "private/config.rkt"
          "private/lock.rkt"
@@ -665,6 +666,7 @@
 (define session-count 0)
 
 (define (handle-handin-request r w)
+  (define init-ms (current-inexact-milliseconds))
   (set! connection-num (add1 connection-num))
   (when ((current-memory-use) . > . (get-conf 'session-memory-limit))
     (log-line "warning: memory use ~s is above session limit of ~s"
@@ -700,7 +702,9 @@
                  (write+flush w 'ver1)
                  (error 'handin "unknown handin version: ~e" ver)))
            (handle-connection r r-safe w)
-           (log-line "normal exit")
+           (log-line "normal exit; took ~a ms"
+                     (~r (- (current-inexact-milliseconds) init-ms)
+                         #:precision 2))
            (kill-watcher)))))))
 
 (define (handle-http-request r w)

--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -613,8 +613,7 @@
              ;;  run-server level
              (custodian-shutdown-all session-cust)
              (loop #t)]
-            [else (collect-garbage)
-                  (log-line "running ~a ~a"
+            [else (log-line "running ~a ~a"
                             (mem (current-memory-use session-cust))
                             (if no-limit-warning?
                                 "(total)"
@@ -668,7 +667,9 @@
 (define (handle-handin-request r w)
   (set! connection-num (add1 connection-num))
   (when ((current-memory-use) . > . (get-conf 'session-memory-limit))
-    (collect-garbage))
+    (log-line "warning: memory use ~s is above session limit of ~s"
+              (current-memory-use)
+              (get-conf 'session-memory-limit)))
   (parameterize ([current-session
                   (begin (set! session-count (add1 session-count))
                          session-count)])
@@ -739,7 +740,7 @@
    (lambda (exn)
      (log-line "ERROR: ~a" (if (exn? exn) (exn-message exn) exn)))
    (lambda (port-k cnt reuse?)
-     (let ([l (ssl-listen port-k cnt #t)])
+     (let ([l (ssl-listen port-k 128 #t)])
        (ssl-load-certificate-chain! l "server-cert.pem")
        (ssl-load-private-key! l "private-key.pem")
        (start-notify)


### PR DESCRIPTION
* Do not perform major collections automatically.
  When the session memory limit is exceeded, print a warning. A
  major collection at this point is unlikely to improve things,
  and instead often causes the server to fail to make progress.

* Set the allowed backlog of SSL connections to 128, instead of the
  default of 5.

@ccshan @mflatt