### PR TITLE
improve docs on "server-cert.pem" and proper signing

### DIFF
--- a/handin-server/scribblings/client-customization.scrbl
+++ b/handin-server/scribblings/client-customization.scrbl
@@ -42,12 +42,15 @@ uniquely.  For example, @filepath{uu-cs1410} is a good name for CS
   according to the course.}
 
 @item{Replace @filepath{server-cert.pem} in your renamed directory
-  with a server certificate, or delete @filepath{server-cert.pem}
-  to rely on a certificate chain.  The file @filepath{server-cert.pem} in
+  with a server certificate, or delete @filepath{server-cert.pem} to
+  rely on a certificate chain. The file @filepath{server-cert.pem} in
   @filepath{handin-client} collection is ok for testing, but the point
-  of this certificate is to make handins secure, so you should
-  either delete it or generate a new (self-certifying) certificate and keep its key
-  private.  (See @secref{server-setup}.)}
+  of this certificate is to make handins secure, so you should either
+  delete it or generate a new self-certifying certificate and keep its
+  key private. If the server is using a properly signed
+  certificate---i.e., not self-signing, but instead with a certificate
+  chain---do @emph{not} include @filepath{server-cert.pem}. (See
+  @secref{server-setup}.)}
 
 @item{To create an installable package, follow the process described
   in @secref[#:doc '(lib "pkg/scribblings/pkg.scrbl")

--- a/handin-server/scribblings/server-setup.scrbl
+++ b/handin-server/scribblings/server-setup.scrbl
@@ -12,9 +12,15 @@ the @envvar{PLT_HANDINSERVER_DIR} environment variable.
 This directory contains the following files and sub-directories:
 @itemize[
 @item{@filepath{server-cert.pem}: the server's certificate.  To create a
-  certificate and key with openssl:
+  self-signed certificate and key with openssl:
   @commandline{openssl req -new -nodes -x509 -days 365
-                 -out server-cert.pem -keyout private-key.pem}}
+                 -out server-cert.pem -keyout private-key.pem}
+
+  Alternatively, use a properly signed certificate. In that case,
+  @filepath{server-cert.pem} should not be included with the client.
+  Beware that distributing a properly signed
+  @filepath{server-cert.pem} can fail with some SSL libraries on the
+  client side.}
 
 @item{@filepath{private-key.pem}: the private key to go with
   @filepath{server-cert.pem}.  Whereas @filepath{server-cert.pem} gets


### PR DESCRIPTION
Try to reflect in the docs what @elibarzilay figured out about distributing properly signed certificates.