### PR TITLE
Allow controlling the `#:readers` value

### DIFF
--- a/handin-server/checker.rkt
+++ b/handin-server/checker.rkt
@@ -375,6 +375,7 @@
             [requires*      (get ':requires      #''())]
             [teachpacks*    (get ':teachpacks    #''())]
             [allowed-requires* (get ':allowed-requires #'#f)]
+            [readers*       (get ':readers       #''auto)]
             [create-text?*  (get ':create-text?  #'#t)]
             [untabify?*     (get ':untabify?     #'#t)]
             [textualize?*   (get ':textualize?   #'#f)]
@@ -421,6 +422,7 @@
                      [language       language*]
                      [requires       requires*]
                      [allowed-requires allowed-requires*]
+                     [readers        readers*]
                      [teachpacks     teachpacks*]
                      [create-text?   create-text?*]
                      [untabify?      untabify?*]
@@ -523,6 +525,7 @@
                                       (call-with-evaluator/submission
                                        language (append requires teachpacks)
                                        #:allowed-requires allowed-requires
+                                       #:readers readers
                                        submission values)))])
                         (set-run-status "running tests")
                         (parameterize ([submission-eval (wrap-evaluator eval)])


### PR DESCRIPTION
In some cases (notably, complicated readers like I use: `#lang pl 03`),
there is no way that I see to guess what the right readers should be, so
allow setting them.