### PR TITLE
Provide get-deadline-seconds

### DIFF
--- a/handin-server/grading-utils.rkt
+++ b/handin-server/grading-utils.rkt
@@ -7,6 +7,7 @@
 (require (only-in handin-server/utils get-assignment-name))
 
 (provide check-deadline
+         get-deadline-seconds
          check-max-submissions 
          
          update-submission-timestamp!


### PR DESCRIPTION
This supports custom handling of late submissions.