### PR TITLE
Fix check-deadline when no deadline is specified

### DIFF
--- a/handin-server/grading-utils.rkt
+++ b/handin-server/grading-utils.rkt
@@ -118,7 +118,7 @@
     [(list _ (list year month day hours minutes seconds) max-late-days)
      (values (find-seconds seconds minutes hours day month year)
              (find-seconds seconds minutes hours (+ day max-late-days) month year))]
-    [else #f]))
+    [else (values #f #f)]))
 
 
 (define (check-deadline)


### PR DESCRIPTION
When no deadline is specified, `check-deadline` currently throws
```
submit error: result arity mismatch;
 expected number of values not received
  expected: 2
  received: 1
  in: local-binding form
  arguments...:
   #false
```
This patch makes the check succeed silently instead.