### PR TITLE
Fix race condition when watcher is killed too fast

### DIFF
--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -650,12 +650,11 @@
                 (proc (lambda ()
                         ;; Proc has succeeded...
                         (parameterize ([current-custodian orig-custodian])
-                          (kill-thread watcher)
-                          ;; unblock the other putting thread if we killed the
-                          ;; watcher too fast.
-                          (channel-try-get watcher-channel))))
+                          (kill-thread watcher))))
                 (channel-put session-channel 'done-normal))))])
-      (channel-put watcher-channel session-thread)
+      ;; if the watcher is dead, give up on the put.
+      (sync (channel-put-evt watcher-channel session-thread)
+            watcher)
       ;; Wait until the proc is done or killed (and kill is reported):
       (channel-get session-channel))))
 


### PR DESCRIPTION
If a client disconnects normally very quickly, the watcher is killed
before its channel is read, causing connection to block indefinitely.
~~To fix, try reading from the watcher's channel after killing it, to
unblock the connection's main thread.~~
To fix, give up on the put if the watcher is dead.

Fixes #55 